### PR TITLE
Fix collapsible list behaviour

### DIFF
--- a/src/components/sdm/ListItem/index.js
+++ b/src/components/sdm/ListItem/index.js
@@ -174,7 +174,8 @@ const ListItemCollapsible = sources => {
 
   const isOpen$ = merge(
       sources.isOpen$,
-      li.click$.map(true).scan((x, a) => !x ? a : !x),
+      sources.isOpen$.startWith(false)
+        .flatMapLatest(isOpen => li.click$.scan(last => !last, isOpen))
     )
     .startWith(false)
 


### PR DESCRIPTION
Previously the list item would not react to the first click after
clicking cancel because the scan would return false for the next value.
Base the scan off the last isOpen value to always do the right thing.
