### PR TITLE
DJ2016 assign to teams

### DIFF
--- a/src/root/Opp/Engaged/Detail.js
+++ b/src/root/Opp/Engaged/Detail.js
@@ -3,7 +3,7 @@ const {just, merge} = Observable
 
 // import {log} from 'util'
 import {combineDOMsToDiv} from 'util'
-import {icon} from 'helpers'
+import {div, p} from 'cycle-snabbdom'
 
 import {
   QuotingListItem,
@@ -61,8 +61,29 @@ const _Intro = sources => DescriptionListItem({...sources,
   default$: just('No intro written.'),
 })
 
+const _PersonalInfo = sources => {
+  const view = ({email, phone}) =>
+    div({}, [
+      div('.row', {}, [
+        p('#email', 'Email: ' + email),
+      ]),
+      div('.row', {}, [
+        p('#phone', 'Phone number: ' + phone),
+      ]),
+    ])
+  return {
+    DOM: sources.profile$.map(view),
+  }
+}
+
 const _ProfileInfo = sources => ({
-  DOM: combineDOMsToDiv('.row', _Avatar(sources), _Intro(sources)),
+  DOM: just(div([
+    combineDOMsToDiv('.row',
+      _Avatar(sources),
+      _Intro(sources)
+    ),
+    combineDOMsToDiv('row', _PersonalInfo(sources)),
+  ])),
 })
 
 const _ViewEngagement = sources => ListItemNewTarget({
@@ -154,12 +175,6 @@ const _TeamsInfo = sources => {
   }
 }
 
-const _Priority = sources => ActionButton({...sources,
-  label$: just('priority'),
-  params$: just({isAccepted: true, priority: true, declined: false}),
-  classNames$: just(['accent']),
-})
-
 const _Accept = sources => ActionButton({...sources,
   label$: just('OK'),
   params$: just({isAccepted: true, priority: false, declined: false}),
@@ -172,21 +187,20 @@ const _Decline = sources => ActionButton({...sources,
 })
 
 const _Remove = sources => hideable(ActionButton)({...sources,
-  label$: just(icon('remove')),
+  label$: just('Delete'),
   params$: just({isAccepted: false, priority: false, declined: true}),
   classNames$: just(['black']),
   isVisible$: sources.userProfile$.pluck('isAdmin'),
 })
 
 const _Actions = (sources) => {
-  const pr = _Priority(sources)
   const ac = _Accept(sources)
   const dec = _Decline(sources)
   const rem = _Remove(sources)
 
   return {
-    DOM: combineDOMsToDiv('.center', pr, ac, dec, rem),
-    action$: merge(pr.action$, ac.action$, dec.action$),
+    DOM: combineDOMsToDiv('.center', ac, dec, rem),
+    action$: merge(ac.action$, dec.action$),
     remove$: rem.action$,
   }
 }

--- a/src/root/Opp/Engaged/Detail.js
+++ b/src/root/Opp/Engaged/Detail.js
@@ -255,7 +255,13 @@ const _AddTeamItem = sources => {
 
   const queue$ = $.merge(createMembership$, updateEngagement$).share()
 
-  return {...li, queue$}
+  const DOM = sources.item$.combineLatest(sources.memberships$,
+    (item, memberships) => !memberships.some(m => m.teamKey === item.$key) ?
+      li.DOM :
+      $.of(div([null]))
+  ).switch()
+
+  return {...li, DOM, queue$}
 }
 
 const _AddToTeam = sources => {


### PR DESCRIPTION
Solution to https://trello.com/c/trCTCI3t/6-2-assign-people-to-other-teams-when-youre-reviewing-their-applications-should-have-a-dropdown-with-teams-that-you-could-possibly

Application view have a dropdown that show the teams that have not been applied/accepted to, and when an organizer selected that team, the volunteer is automatically accepted to the team, and the page is rerouted from the regular applications, to the application that have been accepted to continue viewing the application.
